### PR TITLE
Make ghc database external

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ but nevertheless you get an error message that indicates something went wrong.
 ```
 vabal - The Cabal Companion
 
-Usage: vabal ([-g|--with-ghc-version VER] | [-b|--with-base-version VER])
-             [--flags FLAGS] [--cabal-file FILE] [--no-install]
-             [--always-newest]
+Usage: vabal ([COMMAND] | ([-g|--with-ghc-version VER] |
+             [-b|--with-base-version VER]) [--flags FLAGS] [--cabal-file FILE]
+             [--no-install] [--always-newest])
   Find out a version of the GHC compiler that satisfies the constraints imposed
   on base in the cabal project (By default already installed GHCs are
   preferred). Then print to stdout the path to a GHC compiler with that version
@@ -115,6 +115,9 @@ Available options:
   --always-newest          Always choose newest GHC possible, don't prefer
                            already installed GHCs
   -h,--help                Show this help text
+
+Available commands:
+  update                   Download updated ghc metadata.
 ```
 
 

--- a/lib/VabalContext.hs
+++ b/lib/VabalContext.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE OverloadedStrings #-}
+module VabalContext where
+    
+import Distribution.Version
+import Distribution.Parsec.Class
+
+import Data.Csv
+import Data.List (find, sortOn)
+import Data.Maybe (isJust)
+import Data.Ord (Down(..))
+
+import Data.Foldable (toList)
+
+import qualified Data.ByteString.Lazy as B
+
+data GhcMetadata = GhcMetadata
+                 { ghcVersion  :: Version
+                 , baseVersion :: Version
+                 }
+
+instance Eq GhcMetadata where
+    (GhcMetadata g _) == (GhcMetadata g' _) = g == g'
+
+instance Ord GhcMetadata where
+    compare (GhcMetadata g _) (GhcMetadata g' _) = compare g g'
+
+instance FromNamedRecord GhcMetadata where
+    parseNamedRecord r = do
+        field1  <- r .: "ghcVersion"
+        ghcVer  <- maybe (fail "Expected version") return $ simpleParsec field1
+        field2  <- r .: "baseVersion"
+        baseVer <- maybe (fail "Expected version") return $ simpleParsec field2
+        return $ GhcMetadata ghcVer baseVer
+
+
+newtype GhcToBaseMap = GhcToBaseMap { unwrapMap :: [GhcMetadata] }
+
+emptyMap :: GhcToBaseMap
+emptyMap = GhcToBaseMap []
+
+readGhcToBaseMap :: B.ByteString -> Either String GhcToBaseMap
+readGhcToBaseMap contents = do
+    (_, entries) <- decodeByName contents
+    -- Sort them in descending order, newest first
+    return . GhcToBaseMap . sortOn Down $ toList entries
+
+-- get a submap containing only specified ghc versions
+subMap :: GhcToBaseMap -> [Version] -> GhcToBaseMap
+subMap (GhcToBaseMap m) versions = GhcToBaseMap $
+    filter (\e -> ghcVersion e `elem` versions) m
+
+hasGhcVersion :: GhcToBaseMap -> Version -> Bool
+hasGhcVersion (GhcToBaseMap m) v = isJust $
+   find (\e -> ghcVersion e == v) m
+
+data VabalContext = VabalContext
+                  { availableGhcs   :: GhcToBaseMap
+                  , allGhcInfo      :: GhcToBaseMap
+                  , alwaysNewestGhc :: Bool
+                  }

--- a/src/GhcMetadataDownloader.hs
+++ b/src/GhcMetadataDownloader.hs
@@ -1,0 +1,25 @@
+module GhcMetadataDownloader where
+
+import Network.HTTP.Client as N
+import Network.HTTP.Types.Status as N
+import Network.HTTP.Client.TLS as N
+
+import Data.ByteString.Lazy as B
+
+import VabalError
+
+metadataUrl :: String
+metadataUrl = "https://raw.githubusercontent.com/Franciman/vabal-ghc-metadata/master/ghc-metadata.csv"
+
+downloadGhcMetadata :: FilePath -> IO ()
+downloadGhcMetadata filepath = do
+    manager <- N.newTlsManager
+    request <- N.parseRequest metadataUrl
+    response <- N.httpLbs request manager
+
+    if N.responseStatus response /= N.status200 then
+        throwVabalErrorIO "Error while downloading metadata."
+    else
+        B.writeFile filepath (N.responseBody response)
+
+

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -117,7 +117,7 @@ argsParser = pure Arguments
 commandParser :: Parser Command
 commandParser = subparser
     (command "update" (info (pure Update) (progDesc "Download updated ghc metadata."))
-    <> command "config" (info (RunVabal <$> argsParser) (progDesc "Analyze cabal package."))
+    <> command "run" (info (RunVabal <$> argsParser) (progDesc "Analyze cabal package."))
     )
 main :: IO ()
 main = do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -20,8 +20,12 @@ import Distribution.Parsec.Class
 import Distribution.Parsec.FieldLineStream (fieldLineStreamFromString)
 
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
 
 import Options.Applicative
+
+import VabalContext
+import GhcMetadataDownloader
 
 import Prelude hiding (putStrLn)
 
@@ -47,6 +51,9 @@ data Arguments = Arguments
                , alwaysNewestFlag     :: Bool
                }
                deriving(Show)
+
+data Command = Update
+             | RunVabal Arguments
 
 ghcVersionArgument :: Parser VersionSpecification
 ghcVersionArgument = pure GhcVersion
@@ -107,9 +114,14 @@ argsParser = pure Arguments
                        \ already installed GHCs"
                )
 
+commandParser :: Parser Command
+commandParser = subparser
+    (command "update" (info (pure Update) (progDesc "Download updated ghc metadata."))
+    <> command "config" (info (RunVabal <$> argsParser) (progDesc "Analyze cabal package."))
+    )
 main :: IO ()
 main = do
-    let opts = info (argsParser <**> helper)
+    let opts = info (commandParser <**> helper)
              ( fullDesc
              <> header "vabal - The Cabal Companion"
              <> progDesc "Find out a version of the GHC compiler that satisfies \
@@ -119,7 +131,7 @@ main = do
                          \ with that version (potentially downloading it)."
              )
 
-    args <- execParser opts
+    cmd <- execParser opts
     let errorHandler :: SomeException -> IO ()
         errorHandler ex = do
             writeError $ show ex
@@ -128,45 +140,70 @@ main = do
                        \ something else as PATH to ghc (e.g. the next argument)."
             exitWith (ExitFailure 1)
 
-    catch (vabalMain args) errorHandler
+    handle errorHandler $ do
+        case cmd of
+            Update -> vabalUpdate
+            RunVabal args -> vabalMain args
     return ()
+
+
+getGhcMetadataDir :: IO FilePath
+getGhcMetadataDir = do
+    homeDir <- getHomeDirectory
+    return (homeDir </> ".vabal")
+
+ghcMetadataFilename :: String
+ghcMetadataFilename = "ghcMetadata.csv"
+
+vabalUpdate :: IO ()
+vabalUpdate = do
+    dir <- getGhcMetadataDir
+    createDirectoryIfMissing True dir
+    downloadGhcMetadata (dir </> ghcMetadataFilename)
+    writeOutput "Vabal successfully updated."
 
 vabalMain :: Arguments -> IO ()
 vabalMain args = do
+    ghcMetadataDir <- getGhcMetadataDir
 
     cabalFilePath <- maybe findCabalFile return (cabalFile args)
 
     cabalFileContents <- B.readFile cabalFilePath
 
+    let ghcMetadataPath = ghcMetadataDir </> ghcMetadataFilename
+
+    ghcDb <- readGhcMetadata ghcMetadataPath
+
     let flags = configFlags args
 
-    availableGhcs <- getAvailableGhcs
+    installedGhcs <- subMap ghcDb <$> getInstalledGhcs
+
+    let vabalCtx = VabalContext installedGhcs ghcDb(alwaysNewestFlag args)
 
     version <- case versionSpecification args of
-                    GhcVersion ghcVersion -> do
+                    GhcVersion ghcVer -> do
                         let res = checkIfGivenVersionWorksForAllTargets flags
+                                                                        vabalCtx
                                                                         cabalFileContents
-                                                                        ghcVersion
+                                                                        ghcVer
                         unless res $
                             writeWarning "Warning: The specified ghc version probably won't work."
-                        return ghcVersion
+                        return ghcVer
 
-                    BaseVersion baseVersion -> return $
+                    BaseVersion baseVer -> return $
                                   analyzeCabalFileAllTargets flags
-                                                             (alwaysNewestFlag args)
-                                                             availableGhcs
-                                                             (Just baseVersion)
+                                                             vabalCtx
+                                                             (Just baseVer)
                                                              cabalFileContents
 
                     NoSpecification -> return $
                                   analyzeCabalFileAllTargets flags
-                                                             (alwaysNewestFlag args)
-                                                             availableGhcs
+                                                             vabalCtx
                                                              Nothing
                                                              cabalFileContents
 
 
-    ghcLocation <- requireGHC availableGhcs version (noInstallFlag args)
+    ghcLocation <- requireGHC installedGhcs version (noInstallFlag args)
 
     writeMessage $ "Selected GHC version: " ++ prettyPrintVersion version
     writeOutput ghcLocation
@@ -181,3 +218,14 @@ findCabalFile = do
         [] -> throwVabalErrorIO "No cabal file found."
         (cf:_) -> return cf
 
+readGhcMetadata :: FilePath -> IO GhcToBaseMap
+readGhcMetadata filepath = do
+    fileExists <- doesFileExist filepath
+
+    if not fileExists then
+        throwVabalErrorIO "Ghc metadata not found, run `vabal update` to download it."
+    else do
+      contents <- BL.readFile filepath
+      case readGhcToBaseMap contents of
+        Left err -> throwVabalErrorIO $ "Error, could not parse ghc metadata:\n" ++ err
+        Right res -> return res

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -116,9 +116,8 @@ argsParser = pure Arguments
 
 commandParser :: Parser Command
 commandParser = subparser
-    (command "update" (info (pure Update) (progDesc "Download updated ghc metadata."))
-    <> command "run" (info (RunVabal <$> argsParser) (progDesc "Analyze cabal package."))
-    )
+    (command "update" (info (pure Update) (progDesc "Download updated ghc metadata.")) )
+    <|> (RunVabal <$> argsParser)
 main :: IO ()
 main = do
     let opts = info (commandParser <**> helper)

--- a/vabal.cabal
+++ b/vabal.cabal
@@ -16,13 +16,15 @@ extra-source-files:  CHANGELOG.md
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     CabalAnalyzer, VabalError, GhcDatabase
+  exposed-modules:     CabalAnalyzer, VabalError, GhcDatabase, VabalContext
   other-modules:       GhcVersionChaser
 
   build-depends:       base                 >= 4.11 && < 4.13,
                        -- ^ GHC             >= 8.4.1 && <= 8.6.2
                        Cabal                >= 2.4 && <2.5,
-                       bytestring
+                       bytestring,
+                       cassava,
+                       vector
 
   hs-source-dirs:      lib/
   ghc-options:         -Wall -Wno-unrecognised-pragmas
@@ -30,7 +32,7 @@ library
 
 executable vabal
   main-is:             Main.hs
-  other-modules:       GhcupProgram, UserInterface
+  other-modules:       GhcupProgram, UserInterface, GhcMetadataDownloader
 -- other-extensions:
   build-depends:       base                 >=4.11 && <4.13,
                        -- ^ GHC             >= 8.4.1 && <= 8.6.2
@@ -40,6 +42,10 @@ executable vabal
                        filepath             >= 1.4.2 && < 1.5,
                        optparse-applicative >= 0.14.3 && < 0.15,
                        bytestring,
+                       cassava,
+                       http-client,
+                       http-client-tls,
+                       http-types,
                        vabal
 
   hs-source-dirs:      src/


### PR DESCRIPTION
In this PR the list of ghc versions and their respective base versions is fetched from
this repo: https://github.com/Franciman/vabal-ghc-metadata

I also added `vabal update` and `vabal run` commands.
The first downloads the updated data about ghc versions, the second makes vabal run as usual