### PR TITLE
Consider lib:Cabal and always print ghc path, also when using ghc in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Have you ever upgraded GHC just to find all your haskell projects broken?
 
 Have you ever dreamt about treating `base` as all other packages (i.e. change its version without much thought)?
 
-`vabal` tries to determine a `ghc` version that complies with the `base` package constraints found in the `.cabal` file.
+`vabal` tries to determine a `ghc` version that complies with the `base` package constraints (and
+the `Cabal` package constraints in the setup-depends section, if any) found in the `.cabal` file.
 Then it uses [ghcup](https://github.com/haskell/ghcup) to fetch the compiler (if you don't have it yet)
 and prints to stdout the options to pass to `cabal` to use the fetched compiler.
 
@@ -81,7 +82,8 @@ then it will get a compatible version of `ghc` using `ghcup` (possibly downloadi
 and will finally run `cabal v2-configure` to configure the project with the obtained version of `ghc`.
 
 If everything went fine, you now have your project configured to use a `ghc` compatible
-with the constraints imposed on `base`, you can now build your project as you're used to:
+with the constraints imposed on `base` (and the `Cabal` package constraints in the setup-depends section, if any),
+you can now build your project as you're used to:
 > $ cabal v2-build
 
 You can also enable and disable flags for your package, like this:
@@ -134,8 +136,8 @@ In this mode you can compose `vabal` with other `cabal` commands too, also with 
 ----------
 
 Here are some known gotchas that affect `vabal`:
-- `vabal` trusts the constraints imposed on `base` that it finds in the cabal file,
-therefore it only finds a ghc version that makes it possible to respect the constraints,
+- `vabal` trusts the constraints imposed on `base` (and `Cabal` constraints found in the setup-depends section, if any)
+that it finds in the cabal file, therefore it only finds a ghc version that makes it possible to respect the constraints,
 but it is not guaranteed that the build will be successful. (Generally one should always write correct constraints)
 
 

--- a/lib/CabalAnalyzer.hs
+++ b/lib/CabalAnalyzer.hs
@@ -106,7 +106,7 @@ findCandidate :: FlagAssignment
 findCandidate flags pkgDescr db (vr, ci) = do
     (baseConstraints, cabalLibConstraints) <- constraintsForBaseAndCabalLib flags pkgDescr vr ci
     let db' = entriesWithBaseVersionIn db baseConstraints
-    let db'' = entriesWithMinCabalVersionIn db' cabalLibConstraints
+    let db'' = entriesCompatibleWithCabalVersionRange db' cabalLibConstraints
     fst <$> newest db''
 
 analyzeCabalFileAllTargets :: FlagAssignment

--- a/lib/GhcDatabase.hs
+++ b/lib/GhcDatabase.hs
@@ -60,8 +60,8 @@ newest = M.lookupMax
 entriesWithBaseVersionIn :: GhcDatabase -> VersionRange -> GhcDatabase
 entriesWithBaseVersionIn db vr = M.filter (isVersionInRange vr . baseVersion) db
 
-entriesWithMinCabalVersionIn :: GhcDatabase -> VersionRange -> GhcDatabase
-entriesWithMinCabalVersionIn db vr =
+entriesCompatibleWithCabalVersionRange :: GhcDatabase -> VersionRange -> GhcDatabase
+entriesCompatibleWithCabalVersionRange db vr =
     M.filter (not . isNoVersion . intersectVersionRanges vr . orLaterVersion . minCabalVersion) db
 
 metadataForGhc :: GhcDatabase -> Version -> Maybe GhcMetadata

--- a/lib/GhcMetadata.hs
+++ b/lib/GhcMetadata.hs
@@ -11,7 +11,7 @@ import VabalError
 import System.Directory
 import System.FilePath
 
-import VabalContext
+import GhcDatabase
 
 metadataUrl :: String
 metadataUrl = "https://raw.githubusercontent.com/Franciman/vabal-ghc-metadata/master/vabal-ghc-metadata.csv"
@@ -25,20 +25,20 @@ ghcMetadataFilename :: String
 ghcMetadataFilename = "vabal-ghc-metadata.csv"
 
 
-readGhcMetadata :: FilePath -> IO GhcToBaseMap
-readGhcMetadata filepath = do
+readGhcDatabase :: FilePath -> IO GhcDatabase
+readGhcDatabase filepath = do
     fileExists <- doesFileExist filepath
 
     if not fileExists then
         throwVabalErrorIO "Ghc metadata not found, run `vabal update` to download it."
     else do
       contents <- B.readFile filepath
-      case readGhcToBaseMap contents of
+      case parseGhcDatabase contents of
         Left err -> throwVabalErrorIO $ "Error, could not parse ghc metadata:\n" ++ err
         Right res -> return res
 
-downloadGhcMetadata :: FilePath -> IO ()
-downloadGhcMetadata filepath = do
+downloadGhcDatabase :: FilePath -> IO ()
+downloadGhcDatabase filepath = do
     manager <- N.newTlsManager
     request <- N.parseRequest metadataUrl
     response <- N.httpLbs request manager
@@ -47,5 +47,4 @@ downloadGhcMetadata filepath = do
         throwVabalErrorIO "Error while downloading metadata."
     else
         B.writeFile filepath (N.responseBody response)
-
 

--- a/lib/VabalContext.hs
+++ b/lib/VabalContext.hs
@@ -1,60 +1,9 @@
-{-# LANGUAGE OverloadedStrings #-}
 module VabalContext where
-    
-import Distribution.Version
-import Distribution.Parsec.Class
 
-import Data.Csv
-import Data.List (find, sortOn)
-import Data.Maybe (isJust)
-import Data.Ord (Down(..))
-
-import Data.Foldable (toList)
-
-import qualified Data.ByteString.Lazy as B
-
-data GhcMetadata = GhcMetadata
-                 { ghcVersion  :: Version
-                 , baseVersion :: Version
-                 }
-
-instance Eq GhcMetadata where
-    (GhcMetadata g _) == (GhcMetadata g' _) = g == g'
-
-instance Ord GhcMetadata where
-    compare (GhcMetadata g _) (GhcMetadata g' _) = compare g g'
-
-instance FromNamedRecord GhcMetadata where
-    parseNamedRecord r = do
-        field1  <- r .: "ghcVersion"
-        ghcVer  <- maybe (fail "Expected version") return $ simpleParsec field1
-        field2  <- r .: "baseVersion"
-        baseVer <- maybe (fail "Expected version") return $ simpleParsec field2
-        return $ GhcMetadata ghcVer baseVer
-
-
-newtype GhcToBaseMap = GhcToBaseMap { unwrapMap :: [GhcMetadata] }
-
-emptyMap :: GhcToBaseMap
-emptyMap = GhcToBaseMap []
-
-readGhcToBaseMap :: B.ByteString -> Either String GhcToBaseMap
-readGhcToBaseMap contents = do
-    (_, entries) <- decodeByName contents
-    -- Sort them in descending order, newest first
-    return . GhcToBaseMap . sortOn Down $ toList entries
-
--- get a submap containing only specified ghc versions
-subMap :: GhcToBaseMap -> [Version] -> GhcToBaseMap
-subMap (GhcToBaseMap m) versions = GhcToBaseMap $
-    filter (\e -> ghcVersion e `elem` versions) m
-
-hasGhcVersion :: GhcToBaseMap -> Version -> Bool
-hasGhcVersion (GhcToBaseMap m) v = isJust $
-   find (\e -> ghcVersion e == v) m
+import GhcDatabase
 
 data VabalContext = VabalContext
-                  { availableGhcs   :: GhcToBaseMap
-                  , allGhcInfo      :: GhcToBaseMap
+                  { availableGhcs   :: GhcDatabase
+                  , allGhcInfo      :: GhcDatabase
                   , alwaysNewestGhc :: Bool
                   }

--- a/src/GhcupProgram.hs
+++ b/src/GhcupProgram.hs
@@ -19,7 +19,7 @@ import System.IO (stderr)
 
 import VabalError
 
-import VabalContext
+import GhcDatabase
 
 import System.Process
 import System.Exit
@@ -82,7 +82,7 @@ checkGhcInPath version = do
 -- Asks ghcup to get the provided version for ghc,
 -- It'll return the file path of the downloaded ghc.
 -- If an error occurs a VabalError is thrown.
-requireGHC :: GhcToBaseMap -> Version -> Bool -> IO (Maybe FilePath)
+requireGHC :: GhcDatabase -> Version -> Bool -> IO (Maybe FilePath)
 requireGHC installedGhcs ghcVer noInstall = do
     let version = prettyPrintVersion ghcVer
     ghcPathIsGood <- checkGhcInPath version

--- a/src/VabalMain.hs
+++ b/src/VabalMain.hs
@@ -109,14 +109,12 @@ vabalMain args = do
     writeOutput $ generateCabalOptions args ghcLocation
 
 
-generateCabalOptions :: VabalMainArguments -> Maybe FilePath -> String
+generateCabalOptions :: VabalMainArguments -> FilePath -> String
 generateCabalOptions args ghcLocation =
     let flagsOutput = unwords
               . map showFlagValue $ unFlagAssignment (configFlags args)
 
-        outputGhcLocationArg = case ghcLocation of
-                                 Nothing -> ""
-                                 Just loc -> "-w\n" ++ escapeForXArgs loc
+        outputGhcLocationArg = "-w\n" ++ escapeForXArgs ghcLocation
         outputFlagsArg = if null flagsOutput then
                             ""
                          else
@@ -129,5 +127,5 @@ generateCabalOptions args ghcLocation =
                              Nothing -> ""
                              Just cabalFilePath -> "\n--cabal-file\n" ++ escapeForXArgs cabalFilePath
 
-    in dropWhile (== '\n') $ outputGhcLocationArg ++ outputFlagsArg ++ outputCabalFile -- Remove initial newlines
+    in outputGhcLocationArg ++ outputFlagsArg ++ outputCabalFile
 

--- a/src/VabalMain.hs
+++ b/src/VabalMain.hs
@@ -12,6 +12,8 @@ import System.FilePath
 import VabalError
 
 import VabalContext
+import GhcDatabase
+
 import GhcupProgram
 
 import CabalAnalyzer
@@ -22,6 +24,8 @@ import XArgsEscape
 import Control.Monad (unless)
 
 import qualified Data.ByteString as B
+
+import qualified Data.Set as S
 
 data VabalMainArguments = VabalMainArguments
                { versionSpecification :: VersionSpecification
@@ -70,8 +74,8 @@ vabalMain args = do
     let ghcMetadataPath = ghcMetadataDir </> ghcMetadataFilename
     let flags = configFlags args
 
-    ghcDb <- readGhcMetadata ghcMetadataPath
-    installedGhcs <- subMap ghcDb <$> getInstalledGhcs
+    ghcDb <- readGhcDatabase ghcMetadataPath
+    installedGhcs <- filterGhcVersions ghcDb . S.fromList <$> getInstalledGhcs
 
     let vabalCtx = VabalContext installedGhcs ghcDb(alwaysNewestFlag args)
 
@@ -126,5 +130,4 @@ generateCabalOptions args ghcLocation =
                              Just cabalFilePath -> "\n--cabal-file\n" ++ escapeForXArgs cabalFilePath
 
     in dropWhile (== '\n') $ outputGhcLocationArg ++ outputFlagsArg ++ outputCabalFile -- Remove initial newlines
-
 

--- a/src/VabalUpdate.hs
+++ b/src/VabalUpdate.hs
@@ -12,6 +12,6 @@ vabalUpdate :: IO ()
 vabalUpdate = do
     dir <- getGhcMetadataDir
     createDirectoryIfMissing True dir
-    downloadGhcMetadata (dir </> ghcMetadataFilename)
+    downloadGhcDatabase (dir </> ghcMetadataFilename)
     writeOutput "Vabal successfully updated."
 

--- a/tests/TestOnHackage.hs
+++ b/tests/TestOnHackage.hs
@@ -14,14 +14,15 @@ import Control.Exception
 import Control.DeepSeq
 
 import VabalContext
+import GhcDatabase
 
 import GhcMetadata
 
 import System.Posix.Temp
 
-cabalAnalyzer :: GhcToBaseMap -> (FilePath, Lazy.ByteString) -> IO Bool
+cabalAnalyzer :: GhcDatabase -> (FilePath, Lazy.ByteString) -> IO Bool
 cabalAnalyzer ghcDb (path, pkg) = do
-    let ctx = VabalContext emptyMap ghcDb False
+    let ctx = VabalContext mempty ghcDb False
     let fun = return . analyzeCabalFileAllTargets (mkFlagAssignment []) ctx Nothing . Lazy.toStrict
 
     let errorHandler :: SomeException -> IO Bool
@@ -55,10 +56,10 @@ main = do
 
     withTmpDir "/tmp/vabal-test-on-hackage" $ \tmpDir -> do
 
-        downloadGhcMetadata $ tmpDir </> "ghc-metadata.csv"
+        downloadGhcDatabase $ tmpDir </> "ghc-metadata.csv"
         putStrLn "Metadata downloaded."
 
-        ghcDb <- readGhcMetadata $ tmpDir </> "ghc-metadata.csv"
+        ghcDb <- readGhcDatabase $ tmpDir </> "ghc-metadata.csv"
         putStrLn "Metadata read."
 
         let entries = Tar.read indexContents

--- a/vabal.cabal
+++ b/vabal.cabal
@@ -41,7 +41,8 @@ library
                        http-client          >= 0.5.14 && < 0.6,
                        http-types           >= 0.12.2 && < 0.13,
                        http-client-tls      >= 0.3.5 && < 0.4,
-                       vector               >= 0.12.0 && < 0.13
+                       vector               >= 0.12.0 && < 0.13,
+                       containers
 
   hs-source-dirs:      lib/
   ghc-options:         -Wall
@@ -62,6 +63,7 @@ executable vabal
                        filepath             >= 1.4.2 && < 1.5,
                        optparse-applicative >= 0.14.3 && < 0.15,
                        process              >= 1.6.3 && < 1.7,
+                       containers,
                        vabal
 
   hs-source-dirs:      src/

--- a/vabal.cabal
+++ b/vabal.cabal
@@ -63,7 +63,7 @@ executable vabal
                        filepath             >= 1.4.2 && < 1.5,
                        optparse-applicative >= 0.14.3 && < 0.15,
                        process              >= 1.6.3 && < 1.7,
-                       containers,
+                       containers           >= 0.6.0 && < 0.7,
                        vabal
 
   hs-source-dirs:      src/


### PR DESCRIPTION
Here I implemented the logic to also consider the lib:Cabal version when choosing the ghc version.
This implied a refactoring of the code related to GhcToBaseMap, which was renamed GhcDatabase (an alias for a Map).

This solves #12 and #13
