### PR TITLE
Use cabal to check whether the selected ghc makes the configuration work

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,30 +149,37 @@ but it is not guaranteed that the build will be successful. (Generally one shoul
                            Explicitly tell which version of ghc you want to use
                            for the project. (Incompatible with option
                            --with-base-version)
-                           
   -b,--with-base-version VER
-                           Specify the version of base package you want to use.
-                           It is going to be checked against base constraints in
-                           the cabal file for validity. (Incompatible with
-                           option --with-ghc-version)
-                           
+                           Specify the version of base package you want to use
+                           (it must be specified fully, i.e. 4.11.0.0). It is
+                           going to be checked against base constraints in the
+                           cabal file for validity. (Incompatible with option
+                           --with-ghc-version)
   --flags FLAGS            String containing a list of space separated flags to
                            be used to configure the project (You can enable or
                            disable a flag by adding a + or - in front of the
                            flag name. When none is specified, the flag is
-                           enabled). Flag assignment determined here is also
-                           emitted to stdout as a cabal option
-                           (or passed to "cabal v2-configure" in the case of
-                           "vabal configure")
-                           
+                           enabled). Flag assignment determined here is
+                           forwarded to cabal.
   --cabal-file FILE        Explicitly tell which cabal file to use. This option
-                           also emitted to stdout as cabal option (or passed to
-                           `cabal v2-configure` in the case of "vabal configure")
-  
+                           is forwarded to cabal.
   --no-install             If GHC needs to be downloaded, fail, instead.
-  
   --always-newest          Always choose newest GHC possible, don't prefer
                            already installed GHCs
+  --try-hard               Try configuring the project with each compatible
+                           ghcs, until one succeds. In this way the selected ghc
+                           will be guaranteed to be able to solve constraints.
+                           Differently from '--try-super-hard', if there are
+                           multiple ghcs supporting the same base and Cabal
+                           version, then only one of those is tried, so, for
+                           example after ghc 8.6.3, ghc 8.6.2 is not tried, and
+                           we directly try ghc 8.4.4. (Incompatible with
+                           --try-super-hard)
+  --try-super-hard         Try configuring the project with each compatible
+                           ghcs, until one succeds. In this way the selected ghc
+                           will be guaranteed to be able to solve constraints.
+                           (Incompatible with --try-hard)
+  -h,--help                Show help
 ```
 
 with `vabal configure` you can also pass arguments directly to cabal,

--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ furthermore, these programs are required to be in `PATH`:
 - ghcup,
 - cabal >= 2.4.0.0
 
-`cabal >= 2.4.0.0` is a requirement of `vabal configure`.
-
-`vabal` by itself can be used in combination with older `cabal`, too.
-See the *How to use vabal: full story* paragraph for details.
-
 
  Quick start
 --------------

--- a/src/ArgumentParsers.hs
+++ b/src/ArgumentParsers.hs
@@ -85,3 +85,31 @@ alwaysNewestSwitch = switch
                      <> help "Always choose newest GHC possible, don't prefer \
                              \ already installed GHCs"
                      )
+
+
+data AccurancyLevel = Normal | TryHard | TrySuperHard
+                    deriving(Show)
+
+tryHardSwitch :: Parser AccurancyLevel
+tryHardSwitch = switch
+                ( long "try-hard"
+                <> help "Try configuring the project with each compatible ghcs, until one succeds. \
+                         \ In this way the selected ghc will be guaranteed to be able to solve constraints. \
+                         \ Differently from '--try-super-hard', if there are multiple ghcs \
+                         \ supporting the same base and Cabal version, then only one of those is tried, \
+                         \ so, for example after ghc 8.6.3, ghc 8.6.2 is not tried, and we directly try ghc 8.4.4.\
+                         \ (Incompatible with --try-super-hard)"
+                )
+                *> pure TryHard
+
+trySuperHardSwitch :: Parser AccurancyLevel
+trySuperHardSwitch = switch
+                   ( long "try-super-hard"
+                   <> help "Try configuring the project with each compatible ghcs, until one succeds. \
+                         \ In this way the selected ghc will be guaranteed to be able to solve constraints. \
+                         \ (Incompatible with --try-hard)"
+                   )
+                   *> pure TrySuperHard
+
+accurancySwitches :: Parser AccurancyLevel
+accurancySwitches = tryHardSwitch <|> trySuperHardSwitch <|> pure Normal

--- a/src/VabalUpdate.hs
+++ b/src/VabalUpdate.hs
@@ -2,7 +2,6 @@ module VabalUpdate where
 
 import MetadataManager
 import System.Directory
-import System.FilePath
 import UserInterface
 
 updateProgDesc :: String
@@ -12,6 +11,6 @@ vabalUpdate :: IO ()
 vabalUpdate = do
     dir <- getGhcMetadataDir
     createDirectoryIfMissing True dir
-    downloadGhcDatabase (dir </> ghcMetadataFilename)
+    downloadMetadata dir
     writeOutput "Vabal successfully updated."
 

--- a/vabal.cabal
+++ b/vabal.cabal
@@ -52,7 +52,8 @@ executable vabal
                        http-client          >=0.5.14 && <0.6,
                        http-types           >=0.12.2 && <0.13,
                        http-client-tls      >=0.3.5  && <0.4,
-                       vabal-lib            >=2.0.0  && <2.1.0
+                       vabal-lib            >=2.0.0  && <2.1.0,
+                       tar                  >=0.5.1  && <0.6
 
   hs-source-dirs:      src/
   ghc-options:         -Wall


### PR DESCRIPTION
@zenhack I added the code to run `cabal v2-build` with each compatible `ghc` version to check whether that version is actually compatible with all the constraints and not just with the required `base` and `Cabal` versions.
It can be enabled by two switches:
- `--try-super-hard` tries all `ghc` versions until one succeeds.
- `--try-hard` instead doesn't try all `ghc` versions, but for example if the next ghc it should try supports the same `base` and `Cabal` versions that the previous `ghc` version did, then it won't be tried. So e.g. after `8.6.3` it tries `8.4.4`, not `8.6.2`. In this way the number of failed attempts decreases, but it's not perfect, because there may be some strange reason for which `8.6.2` works but `8.6.3` doesn't (e.g. `if impl(GHC)` conditions in some cabal file).

There is still some polishing to do before merging, but I'd also like to hear your feedbacks.

/CC @fgaz @jabberabbe @lortabac