### PR TITLE
replace freenode with Libera.Chat in README

### DIFF
--- a/vabal/README.md
+++ b/vabal/README.md
@@ -28,7 +28,7 @@ The only change to the global system state `vabal` does is to tell `ghcup` to do
 this behavior can be disabled with `--no-install` flag, so you are always in charge of what's happening!
 
 
-Join our IRC channel `#vabal` on [freenode](https://webchat.freenode.net/) for discussing and getting help from the community.
+Join our IRC channel `#vabal` on [Libera.Chat](https://web.libera.chat/) for discussing and getting help from the community.
 
 
  Requirements


### PR DESCRIPTION
Hi,
since the IRC channel for the vabal community has moved to Libera.Chat we shall change the link to freenode in the README documentation.